### PR TITLE
Clarify distinction between Xcode build settings

### DIFF
--- a/src/ar/index.md
+++ b/src/ar/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // لا حاجة لـ await
 <div class="tip">
 <h4>Approachable Concurrency: احتكاك أقل</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) يبسط النموذج الذهني. لتفعيله، عيّن `SWIFT_VERSION` إلى `6` (أو `5` مع `-enable-upcoming-feature`) و`SWIFT_APPROACHABLE_CONCURRENCY` إلى `YES`. مشاريع Xcode 26 الجديدة تفعّل كليهما افتراضياً.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) يبسط النموذج الذهني من خلال إعدادين في Xcode:
 
-- كل شيء يعمل على MainActor إلا إذا قلت غير ذلك
-- عندما تحتاج عملاً مكثفاً على المعالج بعيداً عن الخيط الرئيسي، استخدم `@concurrent`
-- دوال `nonisolated` غير المتزامنة تبقى على actor المستدعي بدلاً من القفز لخيط خلفي
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: كل شيء يعمل على MainActor إلا إذا قلت غير ذلك
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: دوال `nonisolated` غير المتزامنة تبقى على actor المستدعي بدلاً من القفز لخيط خلفي
 
-كودك يعمل على MainActor. عندما تحتاج عمل خلفي، ضع علامة `@concurrent`. هذا كل شيء.
+مشاريع Xcode 26 الجديدة تفعّل كليهما افتراضياً. عندما تحتاج عملاً مكثفاً على المعالج بعيداً عن الخيط الرئيسي، استخدم `@concurrent`.
 
 <pre><code class="language-swift">// يعمل على MainActor (الافتراضي)
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency: احتكاك أقل</h4>
 
-مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)، أخطاء Sendable تصبح أندر بكثير. لتفعيله، عيّن `SWIFT_VERSION` إلى `6` (أو `5` مع `-enable-upcoming-feature`) و`SWIFT_APPROACHABLE_CONCURRENCY` إلى `YES`. مشاريع Xcode 26 الجديدة تفعّل كليهما افتراضياً.
+مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)، أخطاء Sendable تصبح أندر بكثير:
 
 - إذا كان الكود لا يعبر حدود العزل، لا تحتاج Sendable
 - الدوال غير المتزامنة تبقى على actor المستدعي بدلاً من القفز لخيط خلفي
 - المترجم أذكى في اكتشاف متى تُستخدم القيم بأمان
 
-كودك يعمل على MainActor إلا إذا خرجت صراحةً. عندما تحتاج التوازي، ضع علامة `@concurrent` على الدوال وعندها فكر في Sendable.
+فعّله بتعيين `SWIFT_DEFAULT_ACTOR_ISOLATION` إلى `MainActor` و`SWIFT_APPROACHABLE_CONCURRENCY` إلى `YES`. مشاريع Xcode 26 الجديدة تفعّل كليهما افتراضياً. عندما تحتاج التوازي، ضع علامة `@concurrent` على الدوال وعندها فكر في Sendable.
 </div>
 
 <div class="analogy">

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // No await needed
 <div class="tip">
 <h4>Approachable Concurrency: Less Friction</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifies the mental model. To enable it, set `SWIFT_VERSION` to `6` (or `5` with `-enable-upcoming-feature`) and `SWIFT_APPROACHABLE_CONCURRENCY` to `YES`. New Xcode 26 projects have both enabled by default.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifies the mental model with two Xcode build settings:
 
-- Everything runs on MainActor unless you say otherwise
-- When you need CPU-intensive work off the main thread, use `@concurrent`
-- `nonisolated` async functions stay on the caller's actor instead of jumping to a background thread
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Everything runs on MainActor unless you say otherwise
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async functions stay on the caller's actor instead of jumping to a background thread
 
-Your code runs on MainActor. When you need background work, mark it `@concurrent`. That's it.
+New Xcode 26 projects have both enabled by default. When you need CPU-intensive work off the main thread, use `@concurrent`.
 
 <pre><code class="language-swift">// Runs on MainActor (the default)
 func updateUI() async { }
@@ -367,13 +366,13 @@ The compiler won't verify thread safety. If you're wrong, you'll get data races.
 <div class="tip">
 <h4>Approachable Concurrency: Less Friction</h4>
 
-With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), Sendable errors become much rarer. To enable it, set `SWIFT_VERSION` to `6` (or `5` with `-enable-upcoming-feature`) and `SWIFT_APPROACHABLE_CONCURRENCY` to `YES`. New Xcode 26 projects have both enabled by default.
+With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), Sendable errors become much rarer:
 
 - If code doesn't cross isolation boundaries, you don't need Sendable
 - Async functions stay on the caller's actor instead of hopping to a background thread
 - The compiler is smarter about detecting when values are used safely
 
-Your code runs on MainActor unless you explicitly opt out. When you do need parallelism, mark functions `@concurrent` and then think about Sendable.
+Enable it by setting `SWIFT_DEFAULT_ACTOR_ISOLATION` to `MainActor` and `SWIFT_APPROACHABLE_CONCURRENCY` to `YES`. New Xcode 26 projects have both enabled by default. When you do need parallelism, mark functions `@concurrent` and then think about Sendable.
 </div>
 
 <div class="analogy">

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // No se necesita await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricción</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica el modelo mental. Para habilitarlo, configura `SWIFT_VERSION` a `6` (o `5` con `-enable-upcoming-feature`) y `SWIFT_APPROACHABLE_CONCURRENCY` a `YES`. Los nuevos proyectos de Xcode 26 tienen ambos habilitados por defecto.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica el modelo mental con dos configuraciones de Xcode:
 
-- Todo se ejecuta en MainActor a menos que digas lo contrario
-- Cuando necesites trabajo intensivo de CPU fuera del hilo principal, usa `@concurrent`
-- Las funciones async `nonisolated` permanecen en el actor del llamador en lugar de saltar a un hilo de fondo
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Todo se ejecuta en MainActor a menos que digas lo contrario
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Las funciones async `nonisolated` permanecen en el actor del llamador en lugar de saltar a un hilo de fondo
 
-Tu código se ejecuta en MainActor. Cuando necesitas trabajo en segundo plano, márcalo `@concurrent`. Eso es todo.
+Los nuevos proyectos de Xcode 26 tienen ambos habilitados por defecto. Cuando necesites trabajo intensivo de CPU fuera del hilo principal, usa `@concurrent`.
 
 <pre><code class="language-swift">// Se ejecuta en MainActor (el default)
 func updateUI() async { }
@@ -367,13 +366,13 @@ El compilador no verificará la thread safety. Si te equivocas, tendrás data ra
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricción</h4>
 
-Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), los errores de Sendable se vuelven mucho más raros. Para habilitarlo, configura `SWIFT_VERSION` a `6` (o `5` con `-enable-upcoming-feature`) y `SWIFT_APPROACHABLE_CONCURRENCY` a `YES`. Los nuevos proyectos de Xcode 26 tienen ambos habilitados por defecto.
+Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), los errores de Sendable se vuelven mucho más raros:
 
 - Si el código no cruza límites de aislamiento, no necesitas Sendable
 - Las funciones async permanecen en el actor del llamador en lugar de saltar a un hilo de fondo
 - El compilador es más inteligente detectando cuándo los valores se usan de forma segura
 
-Tu código se ejecuta en MainActor a menos que optes explícitamente por salir. Cuando necesites paralelismo, marca las funciones `@concurrent` y entonces piensa en Sendable.
+Habilítalo configurando `SWIFT_DEFAULT_ACTOR_ISOLATION` a `MainActor` y `SWIFT_APPROACHABLE_CONCURRENCY` a `YES`. Los nuevos proyectos de Xcode 26 tienen ambos habilitados por defecto. Cuando necesites paralelismo, marca las funciones `@concurrent` y entonces piensa en Sendable.
 </div>
 
 <div class="analogy">

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // await 不要
 <div class="tip">
 <h4>親しみやすい並行処理: 摩擦を減らす</h4>
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)はメンタルモデルをシンプルにする。有効にするには、`SWIFT_VERSION` を `6`（または `-enable-upcoming-feature` 付きの `5`）に、`SWIFT_APPROACHABLE_CONCURRENCY` を `YES` に設定する。新しい Xcode 26 プロジェクトではデフォルトで両方が有効になっている。
+[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)は2つの Xcode ビルド設定でメンタルモデルをシンプルにする：
 
-- 他に指定しない限りすべてが MainActor で実行される
-- メインスレッドから外れた CPU 集約的な作業が必要なときは `@concurrent` を使う
-- `nonisolated` async 関数はバックグラウンドスレッドにジャンプする代わりに呼び出し元のアクターにとどまる
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`：他に指定しない限りすべてが MainActor で実行される
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`：`nonisolated` async 関数はバックグラウンドスレッドにジャンプする代わりに呼び出し元のアクターにとどまる
 
-コードは MainActor で実行される。バックグラウンド作業が必要なときは `@concurrent` でマークする。それだけだ。
+新しい Xcode 26 プロジェクトではデフォルトで両方が有効になっている。メインスレッドから外れた CPU 集約的な作業が必要なときは `@concurrent` を使う。
 
 <pre><code class="language-swift">// MainActor で実行（デフォルト）
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>親しみやすい並行処理: 摩擦を減らす</h4>
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)では、Sendable エラーはずっと少なくなる。有効にするには、`SWIFT_VERSION` を `6`（または `-enable-upcoming-feature` 付きの `5`）に、`SWIFT_APPROACHABLE_CONCURRENCY` を `YES` に設定する。新しい Xcode 26 プロジェクトではデフォルトで両方が有効になっている。
+[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)では、Sendable エラーはずっと少なくなる：
 
 - コードが分離境界を越えないなら、Sendable は不要
 - async 関数はバックグラウンドスレッドにホップする代わりに呼び出し元のアクターにとどまる
 - コンパイラは値が安全に使われているかの検出が賢くなる
 
-コードは明示的にオプトアウトしない限り MainActor で実行される。並列性が本当に必要なときは、関数を `@concurrent` でマークしてから Sendable について考えよう。
+`SWIFT_DEFAULT_ACTOR_ISOLATION` を `MainActor` に、`SWIFT_APPROACHABLE_CONCURRENCY` を `YES` に設定して有効にする。新しい Xcode 26 プロジェクトではデフォルトで両方が有効になっている。並列性が本当に必要なときは、関数を `@concurrent` でマークしてから Sendable について考えよう。
 </div>
 
 <div class="analogy">

--- a/src/ko/index.md
+++ b/src/ko/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // await 필요 없음
 <div class="tip">
 <h4>접근하기 쉬운 동시성: 더 적은 마찰</h4>
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)은 멘탈 모델을 단순화합니다. 활성화하려면 `SWIFT_VERSION`을 `6`(또는 `-enable-upcoming-feature`와 함께 `5`)으로, `SWIFT_APPROACHABLE_CONCURRENCY`를 `YES`로 설정하세요. 새 Xcode 26 프로젝트는 둘 다 기본으로 활성화되어 있습니다.
+[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)은 두 가지 Xcode 빌드 설정으로 멘탈 모델을 단순화합니다:
 
-- 다르게 말하지 않으면 모든 것이 MainActor에서 실행됩니다
-- 메인 스레드에서 벗어난 CPU 집약적 작업이 필요하면 `@concurrent`를 사용하세요
-- `nonisolated` async 함수는 백그라운드 스레드로 점프하는 대신 호출자의 액터에 머뭅니다
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: 다르게 말하지 않으면 모든 것이 MainActor에서 실행됩니다
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async 함수는 백그라운드 스레드로 점프하는 대신 호출자의 액터에 머뭅니다
 
-코드가 MainActor에서 실행됩니다. 백그라운드 작업이 필요하면 `@concurrent`로 표시하세요. 그게 다입니다.
+새 Xcode 26 프로젝트는 둘 다 기본으로 활성화되어 있습니다. 메인 스레드에서 벗어난 CPU 집약적 작업이 필요하면 `@concurrent`를 사용하세요.
 
 <pre><code class="language-swift">// MainActor에서 실행됨 (기본값)
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>접근하기 쉬운 동시성: 더 적은 마찰</h4>
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)을 사용하면, Sendable 에러가 훨씬 드물어집니다. 활성화하려면 `SWIFT_VERSION`을 `6`(또는 `-enable-upcoming-feature`와 함께 `5`)으로, `SWIFT_APPROACHABLE_CONCURRENCY`를 `YES`로 설정하세요. 새 Xcode 26 프로젝트는 둘 다 기본으로 활성화되어 있습니다.
+[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)을 사용하면, Sendable 에러가 훨씬 드물어집니다:
 
 - 코드가 격리 경계를 넘지 않으면, Sendable이 필요 없습니다
 - Async 함수가 백그라운드 스레드로 호핑하는 대신 호출자의 액터에 머뭅니다
 - 컴파일러가 값이 안전하게 사용되는지 감지하는 데 더 똑똑해집니다
 
-명시적으로 옵트 아웃하지 않으면 코드가 MainActor에서 실행됩니다. 병렬성이 필요할 때 함수를 `@concurrent`로 표시하고 그 다음에 Sendable을 생각하세요.
+`SWIFT_DEFAULT_ACTOR_ISOLATION`을 `MainActor`로, `SWIFT_APPROACHABLE_CONCURRENCY`를 `YES`로 설정해서 활성화하세요. 새 Xcode 26 프로젝트는 둘 다 기본으로 활성화되어 있습니다. 병렬성이 필요할 때 함수를 `@concurrent`로 표시하고 그 다음에 Sendable을 생각하세요.
 </div>
 
 <div class="analogy">

--- a/src/pt-BR/index.md
+++ b/src/pt-BR/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // Não precisa de await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental. Para habilitar, defina `SWIFT_VERSION` como `6` (ou `5` com `-enable-upcoming-feature`) e `SWIFT_APPROACHABLE_CONCURRENCY` como `YES`. Novos projetos Xcode 26 têm ambos habilitados por padrão.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental com duas configurações do Xcode:
 
-- Tudo roda no MainActor a menos que você diga o contrário
-- Quando você precisa de trabalho intensivo de CPU fora da thread principal, use `@concurrent`
-- Funções async `nonisolated` ficam no actor do chamador em vez de pular para uma thread de segundo plano
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Tudo roda no MainActor a menos que você diga o contrário
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Funções async `nonisolated` ficam no actor do chamador em vez de pular para uma thread de segundo plano
 
-Seu código roda no MainActor. Quando você precisa de trabalho em segundo plano, marque como `@concurrent`. É isso.
+Novos projetos Xcode 26 têm ambos habilitados por padrão. Quando você precisa de trabalho intensivo de CPU fora da thread principal, use `@concurrent`.
 
 <pre><code class="language-swift">// Roda no MainActor (o padrão)
 func updateUI() async { }
@@ -367,13 +366,13 @@ O compilador não vai verificar thread safety. Se você estiver errado, você te
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable se tornam muito mais raros. Para habilitar, defina `SWIFT_VERSION` como `6` (ou `5` com `-enable-upcoming-feature`) e `SWIFT_APPROACHABLE_CONCURRENCY` como `YES`. Novos projetos Xcode 26 têm ambos habilitados por padrão.
+Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable se tornam muito mais raros:
 
 - Se código não cruza fronteiras de isolamento, você não precisa de Sendable
 - Funções async ficam no actor do chamador em vez de pular para uma thread de segundo plano
 - O compilador é mais esperto em detectar quando valores são usados com segurança
 
-Seu código roda no MainActor a menos que você explicitamente opte por sair. Quando você precisa de paralelismo, marque funções como `@concurrent` e então pense em Sendable.
+Habilite configurando `SWIFT_DEFAULT_ACTOR_ISOLATION` como `MainActor` e `SWIFT_APPROACHABLE_CONCURRENCY` como `YES`. Novos projetos Xcode 26 têm ambos habilitados por padrão. Quando você precisa de paralelismo, marque funções como `@concurrent` e então pense em Sendable.
 </div>
 
 <div class="analogy">

--- a/src/pt-PT/index.md
+++ b/src/pt-PT/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // Não precisa de await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental. Para ativar, define `SWIFT_VERSION` para `6` (ou `5` com `-enable-upcoming-feature`) e `SWIFT_APPROACHABLE_CONCURRENCY` para `YES`. Novos projetos do Xcode 26 têm ambos ativados por defeito.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental com duas definições do Xcode:
 
-- Tudo corre no MainActor a menos que digas o contrário
-- Quando precisas de trabalho intensivo de CPU fora da thread principal, usa `@concurrent`
-- Funções async `nonisolated` ficam no actor do chamador em vez de saltar para uma thread de background
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Tudo corre no MainActor a menos que digas o contrário
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Funções async `nonisolated` ficam no actor do chamador em vez de saltar para uma thread de background
 
-O teu código corre no MainActor. Quando precisas de trabalho de background, marca com `@concurrent`. É só isso.
+Novos projetos do Xcode 26 têm ambos ativados por defeito. Quando precisas de trabalho intensivo de CPU fora da thread principal, usa `@concurrent`.
 
 <pre><code class="language-swift">// Corre no MainActor (o defeito)
 func updateUI() async { }
@@ -367,13 +366,13 @@ O compilador não vai verificar thread safety. Se estiveres errado, vais ter dat
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable tornam-se muito mais raros. Para ativar, define `SWIFT_VERSION` para `6` (ou `5` com `-enable-upcoming-feature`) e `SWIFT_APPROACHABLE_CONCURRENCY` para `YES`. Novos projetos do Xcode 26 têm ambos ativados por defeito.
+Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable tornam-se muito mais raros:
 
 - Se o código não cruza fronteiras de isolamento, não precisas de Sendable
 - Funções async ficam no actor do chamador em vez de saltar para uma thread de background
 - O compilador é mais inteligente a detetar quando valores são usados de forma segura
 
-O teu código corre no MainActor a menos que optes explicitamente por sair. Quando precisas de paralelismo, marca funções com `@concurrent` e aí pensa em Sendable.
+Ativa definindo `SWIFT_DEFAULT_ACTOR_ISOLATION` para `MainActor` e `SWIFT_APPROACHABLE_CONCURRENCY` para `YES`. Novos projetos do Xcode 26 têm ambos ativados por defeito. Quando precisas de paralelismo, marca funções com `@concurrent` e aí pensa em Sendable.
 </div>
 
 <div class="analogy">

--- a/src/ru/index.md
+++ b/src/ru/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // await не нужен
 <div class="tip">
 <h4>Approachable Concurrency: меньше трения</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) упрощает ментальную модель. Чтобы включить, установите `SWIFT_VERSION` в `6` (или `5` с `-enable-upcoming-feature`) и `SWIFT_APPROACHABLE_CONCURRENCY` в `YES`. Новые проекты Xcode 26 имеют оба включёнными по умолчанию.
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) упрощает ментальную модель с помощью двух настроек сборки Xcode:
 
-- Всё выполняется на MainActor, если вы не скажете иначе
-- Когда нужна CPU-интенсивная работа вне главного потока, используйте `@concurrent`
-- `nonisolated` async функции остаются на акторе вызывающего вместо прыжка на фоновый поток
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Всё выполняется на MainActor, если вы не скажете иначе
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async функции остаются на акторе вызывающего вместо прыжка на фоновый поток
 
-Ваш код выполняется на MainActor. Когда нужна фоновая работа, пометьте её `@concurrent`. Вот и всё.
+Новые проекты Xcode 26 имеют оба включёнными по умолчанию. Когда нужна CPU-интенсивная работа вне главного потока, используйте `@concurrent`.
 
 <pre><code class="language-swift">// Выполняется на MainActor (по умолчанию)
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency: меньше трения</h4>
 
-С [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ошибки Sendable становятся намного реже. Чтобы включить, установите `SWIFT_VERSION` в `6` (или `5` с `-enable-upcoming-feature`) и `SWIFT_APPROACHABLE_CONCURRENCY` в `YES`. Новые проекты Xcode 26 имеют оба включёнными по умолчанию.
+С [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ошибки Sendable становятся намного реже:
 
 - Если код не пересекает границы изоляции, вам не нужен Sendable
 - Async функции остаются на акторе вызывающего вместо прыжка на фоновый поток
 - Компилятор умнее в определении, когда значения используются безопасно
 
-Ваш код выполняется на MainActor, если вы явно не откажетесь. Когда вам нужен параллелизм, пометьте функции `@concurrent`, и тогда думайте о Sendable.
+Включите, установив `SWIFT_DEFAULT_ACTOR_ISOLATION` в `MainActor` и `SWIFT_APPROACHABLE_CONCURRENCY` в `YES`. Новые проекты Xcode 26 имеют оба включёнными по умолчанию. Когда вам нужен параллелизм, пометьте функции `@concurrent`, и тогда думайте о Sendable.
 </div>
 
 <div class="analogy">

--- a/src/zh-CN/index.md
+++ b/src/zh-CN/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // 不需要 await
 <div class="tip">
 <h4>Approachable Concurrency:更少摩擦</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) 简化了心智模型。要启用它,将 `SWIFT_VERSION` 设为 `6`(或 `5` 加上 `-enable-upcoming-feature`)并将 `SWIFT_APPROACHABLE_CONCURRENCY` 设为 `YES`。新的 Xcode 26 项目默认都启用了。
+[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) 通过两个 Xcode 构建设置简化了心智模型:
 
-- 除非你另外说明,一切都在 MainActor 上运行
-- 当你需要 CPU 密集型工作离开主线程时,用 `@concurrent`
-- `nonisolated` 异步函数留在调用者的 actor 上,而不是跳到后台线程
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: 除非你另外说明,一切都在 MainActor 上运行
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` 异步函数留在调用者的 actor 上,而不是跳到后台线程
 
-你的代码在 MainActor 上运行。当你需要后台工作时,标记为 `@concurrent`。就这样。
+新的 Xcode 26 项目默认都启用了。当你需要 CPU 密集型工作离开主线程时,用 `@concurrent`。
 
 <pre><code class="language-swift">// 在 MainActor 上运行(默认)
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency:更少摩擦</h4>
 
-用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html),Sendable 错误会少很多。要启用它,将 `SWIFT_VERSION` 设为 `6`(或 `5` 加上 `-enable-upcoming-feature`)并将 `SWIFT_APPROACHABLE_CONCURRENCY` 设为 `YES`。新的 Xcode 26 项目默认都启用了。
+用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html),Sendable 错误会少很多:
 
 - 如果代码不跨隔离边界,你不需要 Sendable
 - 异步函数留在调用者的 actor 上,而不是跳到后台线程
 - 编译器更聪明地检测值何时被安全使用
 
-你的代码在 MainActor 上运行,除非你显式选择退出。当你确实需要并行时,标记函数为 `@concurrent`,然后再考虑 Sendable。
+将 `SWIFT_DEFAULT_ACTOR_ISOLATION` 设为 `MainActor` 并将 `SWIFT_APPROACHABLE_CONCURRENCY` 设为 `YES` 来启用。新的 Xcode 26 项目默认都启用了。当你确实需要并行时,标记函数为 `@concurrent`,然后再考虑 Sendable。
 </div>
 
 <div class="analogy">

--- a/src/zh-TW/index.md
+++ b/src/zh-TW/index.md
@@ -275,13 +275,12 @@ let name = account.bankName()  // 不需要 await
 <div class="tip">
 <h4>易於使用的並發：更少摩擦</h4>
 
-[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)簡化了心智模型。要啟用它，把 `SWIFT_VERSION` 設為 `6`（或 `5` 加上 `-enable-upcoming-feature`），並把 `SWIFT_APPROACHABLE_CONCURRENCY` 設為 `YES`。新的 Xcode 26 專案預設兩者都啟用。
+[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)透過兩個 Xcode 建置設定簡化了心智模型：
 
-- 除非你另外說明，所有東西都在 MainActor 上執行
-- 當你需要在主執行緒外進行 CPU 密集型工作時，用 `@concurrent`
-- `nonisolated` async 函式留在呼叫者的 actor 上，而不是跳到背景執行緒
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`：除非你另外說明，所有東西都在 MainActor 上執行
+- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`：`nonisolated` async 函式留在呼叫者的 actor 上，而不是跳到背景執行緒
 
-你的程式碼在 MainActor 上執行。當你需要背景工作時，標記它 `@concurrent`。就這樣。
+新的 Xcode 26 專案預設兩者都啟用。當你需要在主執行緒外進行 CPU 密集型工作時，用 `@concurrent`。
 
 <pre><code class="language-swift">// 在 MainActor 上執行（預設）
 func updateUI() async { }
@@ -367,13 +366,13 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>易於使用的並發：更少摩擦</h4>
 
-有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)，Sendable 錯誤變得少很多。要啟用它，把 `SWIFT_VERSION` 設為 `6`（或 `5` 加上 `-enable-upcoming-feature`），並把 `SWIFT_APPROACHABLE_CONCURRENCY` 設為 `YES`。新的 Xcode 26 專案預設兩者都啟用。
+有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)，Sendable 錯誤變得少很多：
 
 - 如果程式碼不跨越隔離邊界，你不需要 Sendable
 - Async 函式留在呼叫者的 actor 上，而不是跳到背景執行緒
 - 編譯器更聰明地偵測值何時被安全使用
 
-你的程式碼在 MainActor 上執行，除非你明確選擇退出。當你確實需要並行時，標記函式 `@concurrent` 然後再考慮 Sendable。
+把 `SWIFT_DEFAULT_ACTOR_ISOLATION` 設為 `MainActor` 並把 `SWIFT_APPROACHABLE_CONCURRENCY` 設為 `YES` 來啟用。新的 Xcode 26 專案預設兩者都啟用。當你確實需要並行時，標記函式 `@concurrent` 然後再考慮 Sendable。
 </div>
 
 <div class="analogy">


### PR DESCRIPTION
Someone pointed out that the guide was incorrectly attributing "everything runs on MainActor" to `SWIFT_APPROACHABLE_CONCURRENCY` alone. This behavior actually comes from a separate Xcode build setting: `SWIFT_DEFAULT_ACTOR_ISOLATION`.

The tip boxes now clearly explain that there are two distinct settings that work together:

- **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: makes everything run on MainActor by default
- **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: makes `nonisolated` async functions stay on the caller's actor instead of jumping to a background thread

Both are enabled by default in new Xcode 26 projects, but they do different things. Updated across all 10 language versions.