### PR TITLE
updated url to Approachable Concurrency

### DIFF
--- a/src/ar/index.md
+++ b/src/ar/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // لا حاجة لـ await
 <div class="tip">
 <h4>Approachable Concurrency: احتكاك أقل</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) يبسط النموذج الذهني من خلال إعدادين في Xcode:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) يبسط النموذج الذهني من خلال إعدادين في Xcode:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: كل شيء يعمل على MainActor إلا إذا قلت غير ذلك
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: دوال `nonisolated` غير المتزامنة تبقى على actor المستدعي بدلاً من القفز لخيط خلفي
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency: احتكاك أقل</h4>
 
-مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)، أخطاء Sendable تصبح أندر بكثير:
+مع [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)، أخطاء Sendable تصبح أندر بكثير:
 
 - إذا كان الكود لا يعبر حدود العزل، لا تحتاج Sendable
 - الدوال غير المتزامنة تبقى على actor المستدعي بدلاً من القفز لخيط خلفي
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 رأيت أن نطاقات العزل تحمي البيانات، وSendable يتحكم فيما يعبر بينها. لكن كيف ينتهي الكود في نطاق عزل في الأصل؟
 
-عندما تستدعي دالة أو تنشئ closure، العزل يتدفق عبر كودك. مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)، تطبيقك يبدأ على [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)، وذلك العزل ينتشر للكود الذي تستدعيه، إلا إذا غيّره شيء صراحةً. فهم هذا التدفق يساعدك على التنبؤ أين يعمل الكود ولماذا المترجم أحياناً يشتكي.
+عندما تستدعي دالة أو تنشئ closure، العزل يتدفق عبر كودك. مع [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)، تطبيقك يبدأ على [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)، وذلك العزل ينتشر للكود الذي تستدعيه، إلا إذا غيّره شيء صراحةً. فهم هذا التدفق يساعدك على التنبؤ أين يعمل الكود ولماذا المترجم أحياناً يشتكي.
 
 ### استدعاءات الدوال
 
@@ -408,7 +408,7 @@ func helper() { }                    // ترث عزل المستدعي
 @concurrent func crunch() async { }  // صراحةً تعمل بعيداً عن الـ actor
 ```
 
-مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)، معظم كودك يرث عزل `MainActor`. الدالة تعمل حيث يعمل المستدعي، إلا إذا خرجت صراحةً.
+مع [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)، معظم كودك يرث عزل `MainActor`. الدالة تعمل حيث يعمل المستدعي، إلا إذا خرجت صراحةً.
 
 ### الـ Closures
 
@@ -492,7 +492,7 @@ class ViewModel {
 
 التزامن في Swift قد يشعر بالكثير من المفاهيم: `async/await`، `Task`، الـ actors، `MainActor`، `Sendable`، نطاقات العزل. لكن هناك فكرة واحدة فقط في المركز: **العزل يُورَث افتراضياً**.
 
-مع [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) مفعّل، تطبيقك يبدأ على [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). هذه نقطة بدايتك. من هناك:
+مع [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) مفعّل، تطبيقك يبدأ على [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). هذه نقطة بدايتك. من هناك:
 
 - كل دالة تستدعيها **ترث** ذلك العزل
 - كل closure تنشئها **تلتقط** ذلك العزل

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // No await needed
 <div class="tip">
 <h4>Approachable Concurrency: Less Friction</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifies the mental model with two Xcode build settings:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) simplifies the mental model with two Xcode build settings:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Everything runs on MainActor unless you say otherwise
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async functions stay on the caller's actor instead of jumping to a background thread
@@ -366,7 +366,7 @@ The compiler won't verify thread safety. If you're wrong, you'll get data races.
 <div class="tip">
 <h4>Approachable Concurrency: Less Friction</h4>
 
-With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), Sendable errors become much rarer:
+With [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), Sendable errors become much rarer:
 
 - If code doesn't cross isolation boundaries, you don't need Sendable
 - Async functions stay on the caller's actor instead of hopping to a background thread
@@ -396,7 +396,7 @@ Back to the office building. When you need to share information between departme
 
 You've seen that isolation domains protect data, and Sendable controls what crosses between them. But how does code end up in an isolation domain in the first place?
 
-When you call a function or create a closure, isolation flows through your code. With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), your app starts on [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), and that isolation propagates to the code you call, unless something explicitly changes it. Understanding this flow helps you predict where code runs and why the compiler sometimes complains.
+When you call a function or create a closure, isolation flows through your code. With [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), your app starts on [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), and that isolation propagates to the code you call, unless something explicitly changes it. Understanding this flow helps you predict where code runs and why the compiler sometimes complains.
 
 ### Function Calls
 
@@ -408,7 +408,7 @@ func helper() { }                    // Inherits caller's isolation
 @concurrent func crunch() async { }  // Explicitly runs off-actor
 ```
 
-With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), most of your code inherits `MainActor` isolation. The function runs where the caller runs, unless it explicitly opts out.
+With [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), most of your code inherits `MainActor` isolation. The function runs where the caller runs, unless it explicitly opts out.
 
 ### Closures
 
@@ -492,7 +492,7 @@ Let's step back and see how all the pieces fit.
 
 Swift Concurrency can feel like a lot of concepts: `async/await`, `Task`, actors, `MainActor`, `Sendable`, isolation domains. But there's really just one idea at the center of it all: **isolation is inherited by default**.
 
-With [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) enabled, your app starts on [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). That's your starting point. From there:
+With [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) enabled, your app starts on [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). That's your starting point. From there:
 
 - Every function you call **inherits** that isolation
 - Every closure you create **captures** that isolation

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // No se necesita await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricción</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica el modelo mental con dos configuraciones de Xcode:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) simplifica el modelo mental con dos configuraciones de Xcode:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Todo se ejecuta en MainActor a menos que digas lo contrario
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Las funciones async `nonisolated` permanecen en el actor del llamador en lugar de saltar a un hilo de fondo
@@ -366,7 +366,7 @@ El compilador no verificará la thread safety. Si te equivocas, tendrás data ra
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricción</h4>
 
-Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), los errores de Sendable se vuelven mucho más raros:
+Con [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), los errores de Sendable se vuelven mucho más raros:
 
 - Si el código no cruza límites de aislamiento, no necesitas Sendable
 - Las funciones async permanecen en el actor del llamador en lugar de saltar a un hilo de fondo
@@ -396,7 +396,7 @@ Los tipos `Sendable` son como fotocopias: seguros de compartir porque cada lugar
 
 Has visto que los dominios de aislamiento protegen los datos, y Sendable controla qué cruza entre ellos. ¿Pero cómo termina el código en un dominio de aislamiento en primer lugar?
 
-Cuando llamas a una función o creas un closure, el aislamiento fluye a través de tu código. Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), tu app comienza en [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), y ese aislamiento se propaga al código que llamas, a menos que algo lo cambie explícitamente. Entender este flujo te ayuda a predecir dónde se ejecuta el código y por qué el compilador a veces se queja.
+Cuando llamas a una función o creas un closure, el aislamiento fluye a través de tu código. Con [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), tu app comienza en [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), y ese aislamiento se propaga al código que llamas, a menos que algo lo cambie explícitamente. Entender este flujo te ayuda a predecir dónde se ejecuta el código y por qué el compilador a veces se queja.
 
 ### Llamadas a Funciones
 
@@ -408,7 +408,7 @@ func helper() { }                    // Hereda el aislamiento del llamador
 @concurrent func crunch() async { }  // Explícitamente se ejecuta fuera del actor
 ```
 
-Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), la mayor parte de tu código hereda el aislamiento de `MainActor`. La función se ejecuta donde se ejecuta el llamador, a menos que opte explícitamente por salir.
+Con [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), la mayor parte de tu código hereda el aislamiento de `MainActor`. La función se ejecuta donde se ejecuta el llamador, a menos que opte explícitamente por salir.
 
 ### Closures
 
@@ -492,7 +492,7 @@ Demos un paso atrás y veamos cómo encajan todas las piezas.
 
 Swift Concurrency puede parecer muchos conceptos: `async/await`, `Task`, actors, `MainActor`, `Sendable`, dominios de aislamiento. Pero realmente hay solo una idea en el centro de todo: **el aislamiento se hereda por defecto**.
 
-Con [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) habilitado, tu app comienza en [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Ese es tu punto de partida. Desde ahí:
+Con [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) habilitado, tu app comienza en [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Ese es tu punto de partida. Desde ahí:
 
 - Cada función que llamas **hereda** ese aislamiento
 - Cada closure que creas **captura** ese aislamiento

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // await 不要
 <div class="tip">
 <h4>親しみやすい並行処理: 摩擦を減らす</h4>
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)は2つの Xcode ビルド設定でメンタルモデルをシンプルにする：
+[親しみやすい並行処理](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)は2つの Xcode ビルド設定でメンタルモデルをシンプルにする：
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`：他に指定しない限りすべてが MainActor で実行される
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`：`nonisolated` async 関数はバックグラウンドスレッドにジャンプする代わりに呼び出し元のアクターにとどまる
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>親しみやすい並行処理: 摩擦を減らす</h4>
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)では、Sendable エラーはずっと少なくなる：
+[親しみやすい並行処理](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)では、Sendable エラーはずっと少なくなる：
 
 - コードが分離境界を越えないなら、Sendable は不要
 - async 関数はバックグラウンドスレッドにホップする代わりに呼び出し元のアクターにとどまる
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 分離ドメインがデータを保護し、Sendable がその間を越えるものを制御することを見てきた。でも、そもそもコードはどうやって分離ドメインに入るのか？
 
-関数を呼び出したりクロージャを作成したりすると、分離はコードを通じて流れる。[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)では、アプリは [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) から始まり、何かが明示的に変更しない限り、その分離は呼び出すコードに伝播する。このフローを理解することで、コードがどこで実行されるか、なぜコンパイラが時々文句を言うかを予測できる。
+関数を呼び出したりクロージャを作成したりすると、分離はコードを通じて流れる。[親しみやすい並行処理](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)では、アプリは [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) から始まり、何かが明示的に変更しない限り、その分離は呼び出すコードに伝播する。このフローを理解することで、コードがどこで実行されるか、なぜコンパイラが時々文句を言うかを予測できる。
 
 ### 関数呼び出し
 
@@ -408,7 +408,7 @@ func helper() { }                    // 呼び出し元の分離を継承
 @concurrent func crunch() async { }  // 明示的にオフアクターで実行
 ```
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)では、ほとんどのコードが `MainActor` 分離を継承する。関数は呼び出し元がいる場所で実行される - 明示的にオプトアウトしない限り。
+[親しみやすい並行処理](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)では、ほとんどのコードが `MainActor` 分離を継承する。関数は呼び出し元がいる場所で実行される - 明示的にオプトアウトしない限り。
 
 ### クロージャ
 
@@ -492,7 +492,7 @@ Swift チームは [Task.detached を最後の手段として](https://forums.sw
 
 Swift 並行処理は多くの概念に感じられる: `async/await`、`Task`、アクター、`MainActor`、`Sendable`、分離ドメイン。でも実際には中心にあるのは一つのアイデアだけだ: **分離はデフォルトで継承される**。
 
-[親しみやすい並行処理](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)を有効にすると、アプリは [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) から始まる。それが出発点だ。そこから:
+[親しみやすい並行処理](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)を有効にすると、アプリは [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) から始まる。それが出発点だ。そこから:
 
 - 呼び出すすべての関数がその分離を**継承**する
 - 作成するすべてのクロージャがその分離を**キャプチャ**する

--- a/src/ko/index.md
+++ b/src/ko/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // await 필요 없음
 <div class="tip">
 <h4>접근하기 쉬운 동시성: 더 적은 마찰</h4>
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)은 두 가지 Xcode 빌드 설정으로 멘탈 모델을 단순화합니다:
+[접근하기 쉬운 동시성](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)은 두 가지 Xcode 빌드 설정으로 멘탈 모델을 단순화합니다:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: 다르게 말하지 않으면 모든 것이 MainActor에서 실행됩니다
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async 함수는 백그라운드 스레드로 점프하는 대신 호출자의 액터에 머뭅니다
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>접근하기 쉬운 동시성: 더 적은 마찰</h4>
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)을 사용하면, Sendable 에러가 훨씬 드물어집니다:
+[접근하기 쉬운 동시성](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)을 사용하면, Sendable 에러가 훨씬 드물어집니다:
 
 - 코드가 격리 경계를 넘지 않으면, Sendable이 필요 없습니다
 - Async 함수가 백그라운드 스레드로 호핑하는 대신 호출자의 액터에 머뭅니다
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 격리 도메인이 데이터를 보호하고, Sendable이 그들 사이를 넘나드는 것을 제어하는 걸 보셨습니다. 하지만 코드가 처음에 어떻게 격리 도메인에 들어가게 되나요?
 
-함수를 호출하거나 클로저를 생성할 때, 격리가 코드를 통해 흐릅니다. [접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)에서 앱은 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)에서 시작하고, 무언가가 명시적으로 변경하지 않는 한 그 격리가 호출하는 코드로 전파됩니다. 이 흐름을 이해하면 코드가 어디서 실행되는지, 왜 컴파일러가 가끔 불평하는지 예측하는 데 도움이 됩니다.
+함수를 호출하거나 클로저를 생성할 때, 격리가 코드를 통해 흐릅니다. [접근하기 쉬운 동시성](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)에서 앱은 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)에서 시작하고, 무언가가 명시적으로 변경하지 않는 한 그 격리가 호출하는 코드로 전파됩니다. 이 흐름을 이해하면 코드가 어디서 실행되는지, 왜 컴파일러가 가끔 불평하는지 예측하는 데 도움이 됩니다.
 
 ### 함수 호출
 
@@ -408,7 +408,7 @@ func helper() { }                    // 호출자의 격리 상속
 @concurrent func crunch() async { }  // 명시적으로 액터 외부에서 실행
 ```
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)에서 대부분의 코드는 `MainActor` 격리를 상속합니다. 명시적으로 옵트 아웃하지 않으면 함수는 호출자가 실행되는 곳에서 실행됩니다.
+[접근하기 쉬운 동시성](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)에서 대부분의 코드는 `MainActor` 격리를 상속합니다. 명시적으로 옵트 아웃하지 않으면 함수는 호출자가 실행되는 곳에서 실행됩니다.
 
 ### 클로저
 
@@ -492,7 +492,7 @@ Swift 팀은 [Task.detached를 최후의 수단으로 권장합니다](https://f
 
 Swift 동시성은 많은 개념처럼 느껴질 수 있습니다: `async/await`, `Task`, 액터, `MainActor`, `Sendable`, 격리 도메인. 하지만 정말 그 중심에는 하나의 아이디어만 있습니다: **격리는 기본적으로 상속됩니다**.
 
-[접근하기 쉬운 동시성](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)이 활성화되면, 앱은 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)에서 시작합니다. 그게 시작점입니다. 거기서부터:
+[접근하기 쉬운 동시성](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)이 활성화되면, 앱은 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor)에서 시작합니다. 그게 시작점입니다. 거기서부터:
 
 - 호출하는 모든 함수가 그 격리를 **상속**합니다
 - 생성하는 모든 클로저가 그 격리를 **캡처**합니다

--- a/src/pt-BR/index.md
+++ b/src/pt-BR/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // Não precisa de await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental com duas configurações do Xcode:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) simplifica o modelo mental com duas configurações do Xcode:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Tudo roda no MainActor a menos que você diga o contrário
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Funções async `nonisolated` ficam no actor do chamador em vez de pular para uma thread de segundo plano
@@ -366,7 +366,7 @@ O compilador não vai verificar thread safety. Se você estiver errado, você te
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable se tornam muito mais raros:
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), erros de Sendable se tornam muito mais raros:
 
 - Se código não cruza fronteiras de isolamento, você não precisa de Sendable
 - Funções async ficam no actor do chamador em vez de pular para uma thread de segundo plano
@@ -396,7 +396,7 @@ Tipos `Sendable` são como fotocópias: seguros para compartilhar porque cada lu
 
 Você viu que domínios de isolamento protegem dados, e Sendable controla o que cruza entre eles. Mas como código acaba em um domínio de isolamento em primeiro lugar?
 
-Quando você chama uma função ou cria um closure, isolamento flui através do seu código. Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), seu app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), e esse isolamento se propaga para o código que você chama, a menos que algo explicitamente mude isso. Entender esse fluxo te ajuda a prever onde código roda e por que o compilador às vezes reclama.
+Quando você chama uma função ou cria um closure, isolamento flui através do seu código. Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), seu app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), e esse isolamento se propaga para o código que você chama, a menos que algo explicitamente mude isso. Entender esse fluxo te ajuda a prever onde código roda e por que o compilador às vezes reclama.
 
 ### Chamadas de Função
 
@@ -408,7 +408,7 @@ func helper() { }                    // Herda isolamento do chamador
 @concurrent func crunch() async { }  // Explicitamente roda fora do actor
 ```
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), a maior parte do seu código herda isolamento do `MainActor`. A função roda onde o chamador roda, a menos que ela explicitamente opte por sair.
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), a maior parte do seu código herda isolamento do `MainActor`. A função roda onde o chamador roda, a menos que ela explicitamente opte por sair.
 
 ### Closures
 
@@ -492,7 +492,7 @@ Vamos dar um passo atrás e ver como todas as peças se encaixam.
 
 Swift Concurrency pode parecer um monte de conceitos: `async/await`, `Task`, actors, `MainActor`, `Sendable`, domínios de isolamento. Mas existe realmente só uma ideia no centro de tudo: **isolamento é herdado por padrão**.
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) habilitado, seu app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Esse é seu ponto de partida. A partir daí:
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) habilitado, seu app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Esse é seu ponto de partida. A partir daí:
 
 - Toda função que você chama **herda** esse isolamento
 - Todo closure que você cria **captura** esse isolamento

--- a/src/pt-PT/index.md
+++ b/src/pt-PT/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // Não precisa de await
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) simplifica o modelo mental com duas definições do Xcode:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) simplifica o modelo mental com duas definições do Xcode:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Tudo corre no MainActor a menos que digas o contrário
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: Funções async `nonisolated` ficam no actor do chamador em vez de saltar para uma thread de background
@@ -366,7 +366,7 @@ O compilador não vai verificar thread safety. Se estiveres errado, vais ter dat
 <div class="tip">
 <h4>Approachable Concurrency: Menos Fricção</h4>
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), erros de Sendable tornam-se muito mais raros:
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), erros de Sendable tornam-se muito mais raros:
 
 - Se o código não cruza fronteiras de isolamento, não precisas de Sendable
 - Funções async ficam no actor do chamador em vez de saltar para uma thread de background
@@ -396,7 +396,7 @@ Tipos `Sendable` são como fotocópias: seguros de partilhar porque cada lugar r
 
 Viste que os domínios de isolamento protegem dados, e Sendable controla o que cruza entre eles. Mas como é que o código acaba num domínio de isolamento em primeiro lugar?
 
-Quando chamas uma função ou crias um closure, o isolamento flui através do teu código. Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), a tua app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), e esse isolamento propaga-se para o código que chamas, a menos que algo o mude explicitamente. Compreender este fluxo ajuda-te a prever onde o código corre e porque é que o compilador às vezes se queixa.
+Quando chamas uma função ou crias um closure, o isolamento flui através do teu código. Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), a tua app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), e esse isolamento propaga-se para o código que chamas, a menos que algo o mude explicitamente. Compreender este fluxo ajuda-te a prever onde o código corre e porque é que o compilador às vezes se queixa.
 
 ### Chamadas de Funções
 
@@ -408,7 +408,7 @@ func helper() { }                    // Herda o isolamento do chamador
 @concurrent func crunch() async { }  // Corre explicitamente fora do actor
 ```
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html), a maior parte do teu código herda isolamento do `MainActor`. A função corre onde o chamador corre, a menos que opte explicitamente por sair.
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency), a maior parte do teu código herda isolamento do `MainActor`. A função corre onde o chamador corre, a menos que opte explicitamente por sair.
 
 ### Closures
 
@@ -492,7 +492,7 @@ Vamos recuar e ver como todas as peças encaixam.
 
 Swift Concurrency pode parecer muitos conceitos: `async/await`, `Task`, actors, `MainActor`, `Sendable`, domínios de isolamento. Mas há realmente só uma ideia no centro de tudo: **o isolamento é herdado por defeito**.
 
-Com [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ativado, a tua app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Esse é o teu ponto de partida. A partir daí:
+Com [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) ativado, a tua app começa no [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Esse é o teu ponto de partida. A partir daí:
 
 - Cada função que chamas **herda** esse isolamento
 - Cada closure que crias **captura** esse isolamento

--- a/src/ru/index.md
+++ b/src/ru/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // await не нужен
 <div class="tip">
 <h4>Approachable Concurrency: меньше трения</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) упрощает ментальную модель с помощью двух настроек сборки Xcode:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) упрощает ментальную модель с помощью двух настроек сборки Xcode:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: Всё выполняется на MainActor, если вы не скажете иначе
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` async функции остаются на акторе вызывающего вместо прыжка на фоновый поток
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency: меньше трения</h4>
 
-С [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ошибки Sendable становятся намного реже:
+С [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) ошибки Sendable становятся намного реже:
 
 - Если код не пересекает границы изоляции, вам не нужен Sendable
 - Async функции остаются на акторе вызывающего вместо прыжка на фоновый поток
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 Вы видели, что домены изоляции защищают данные, а Sendable контролирует, что пересекает границы между ними. Но как код вообще оказывается в домене изоляции?
 
-Когда вы вызываете функцию или создаёте замыкание, изоляция течёт через ваш код. С [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ваше приложение стартует на [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), и эта изоляция распространяется на код, который вы вызываете, если только что-то явно её не меняет. Понимание этого потока помогает предсказать, где выполняется код и почему компилятор иногда жалуется.
+Когда вы вызываете функцию или создаёте замыкание, изоляция течёт через ваш код. С [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) ваше приложение стартует на [`MainActor`](https://developer.apple.com/documentation/swift/mainactor), и эта изоляция распространяется на код, который вы вызываете, если только что-то явно её не меняет. Понимание этого потока помогает предсказать, где выполняется код и почему компилятор иногда жалуется.
 
 ### Вызовы функций
 
@@ -408,7 +408,7 @@ func helper() { }                    // Наследует изоляцию вы
 @concurrent func crunch() async { }  // Явно выполняется вне актора
 ```
 
-С [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) большая часть вашего кода наследует изоляцию `MainActor`. Функция выполняется там, где выполняется вызывающий, если она явно не отказывается.
+С [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) большая часть вашего кода наследует изоляцию `MainActor`. Функция выполняется там, где выполняется вызывающий, если она явно не отказывается.
 
 ### Замыкания
 
@@ -492,7 +492,7 @@ class ViewModel {
 
 Swift Concurrency может ощущаться как куча концепций: `async/await`, `Task`, акторы, `MainActor`, `Sendable`, домены изоляции. Но на самом деле в центре всего одна идея: **изоляция наследуется по умолчанию**.
 
-С включённым [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) ваше приложение стартует на [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Это ваша отправная точка. Оттуда:
+С включённым [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) ваше приложение стартует на [`MainActor`](https://developer.apple.com/documentation/swift/mainactor). Это ваша отправная точка. Оттуда:
 
 - Каждая функция, которую вы вызываете, **наследует** эту изоляцию
 - Каждое замыкание, которое вы создаёте, **захватывает** эту изоляцию

--- a/src/zh-CN/index.md
+++ b/src/zh-CN/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // 不需要 await
 <div class="tip">
 <h4>Approachable Concurrency:更少摩擦</h4>
 
-[Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) 通过两个 Xcode 构建设置简化了心智模型:
+[Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) 通过两个 Xcode 构建设置简化了心智模型:
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`: 除非你另外说明,一切都在 MainActor 上运行
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`: `nonisolated` 异步函数留在调用者的 actor 上,而不是跳到后台线程
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>Approachable Concurrency:更少摩擦</h4>
 
-用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html),Sendable 错误会少很多:
+用 [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency),Sendable 错误会少很多:
 
 - 如果代码不跨隔离边界,你不需要 Sendable
 - 异步函数留在调用者的 actor 上,而不是跳到后台线程
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 你已经看到隔离域保护数据,Sendable 控制什么可以跨越它们。但代码一开始怎么进入隔离域的?
 
-当你调用函数或创建闭包时,隔离会流经你的代码。用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html),你的应用从 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 开始,这个隔离传播到你调用的代码,除非有东西显式改变它。理解这个流动帮助你预测代码在哪里运行,以及为什么编译器有时会抱怨。
+当你调用函数或创建闭包时,隔离会流经你的代码。用 [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency),你的应用从 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 开始,这个隔离传播到你调用的代码,除非有东西显式改变它。理解这个流动帮助你预测代码在哪里运行,以及为什么编译器有时会抱怨。
 
 ### 函数调用
 
@@ -408,7 +408,7 @@ func helper() { }                    // 继承调用者的隔离
 @concurrent func crunch() async { }  // 显式在后台运行
 ```
 
-用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html),你的大部分代码继承 `MainActor` 隔离。函数在调用者运行的地方运行,除非它显式选择退出。
+用 [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency),你的大部分代码继承 `MainActor` 隔离。函数在调用者运行的地方运行,除非它显式选择退出。
 
 ### 闭包
 
@@ -492,7 +492,7 @@ Swift 团队推荐 [Task.detached 作为最后手段](https://forums.swift.org/t
 
 Swift 并发感觉像很多概念:`async/await`、`Task`、actors、`MainActor`、`Sendable`、隔离域。但其实中心只有一个想法:**隔离默认被继承。**
 
-启用 [Approachable Concurrency](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html) 后,你的应用从 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 开始。这是你的起点。从那里:
+启用 [Approachable Concurrency](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency) 后,你的应用从 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 开始。这是你的起点。从那里:
 
 - 你调用的每个函数**继承**那个隔离
 - 你创建的每个闭包**捕获**那个隔离

--- a/src/zh-TW/index.md
+++ b/src/zh-TW/index.md
@@ -275,7 +275,7 @@ let name = account.bankName()  // 不需要 await
 <div class="tip">
 <h4>易於使用的並發：更少摩擦</h4>
 
-[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)透過兩個 Xcode 建置設定簡化了心智模型：
+[易於使用的並發](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)透過兩個 Xcode 建置設定簡化了心智模型：
 
 - **`SWIFT_DEFAULT_ACTOR_ISOLATION`** = `MainActor`：除非你另外說明，所有東西都在 MainActor 上執行
 - **`SWIFT_APPROACHABLE_CONCURRENCY`** = `YES`：`nonisolated` async 函式留在呼叫者的 actor 上，而不是跳到背景執行緒
@@ -366,7 +366,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 <div class="tip">
 <h4>易於使用的並發：更少摩擦</h4>
 
-有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)，Sendable 錯誤變得少很多：
+有了[易於使用的並發](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)，Sendable 錯誤變得少很多：
 
 - 如果程式碼不跨越隔離邊界，你不需要 Sendable
 - Async 函式留在呼叫者的 actor 上，而不是跳到背景執行緒
@@ -396,7 +396,7 @@ final class ThreadSafeCache: @unchecked Sendable {
 
 你已經看到隔離域保護資料，而 Sendable 控制什麼可以在它們之間跨越。但程式碼一開始是怎麼進入一個隔離域的？
 
-當你呼叫一個函式或建立一個閉包時，隔離會流過你的程式碼。有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)，你的 app 從 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 開始，那個隔離會傳播到你呼叫的程式碼，除非有東西明確改變它。理解這個流動幫助你預測程式碼在哪裡執行，以及為什麼編譯器有時會抱怨。
+當你呼叫一個函式或建立一個閉包時，隔離會流過你的程式碼。有了[易於使用的並發](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)，你的 app 從 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 開始，那個隔離會傳播到你呼叫的程式碼，除非有東西明確改變它。理解這個流動幫助你預測程式碼在哪裡執行，以及為什麼編譯器有時會抱怨。
 
 ### 函式呼叫
 
@@ -408,7 +408,7 @@ func helper() { }                    // 繼承呼叫者的隔離
 @concurrent func crunch() async { }  // 明確在 actor 外執行
 ```
 
-有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)，你大部分的程式碼繼承 `MainActor` 隔離。函式在呼叫者執行的地方執行，除非它明確選擇退出。
+有了[易於使用的並發](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)，你大部分的程式碼繼承 `MainActor` 隔離。函式在呼叫者執行的地方執行，除非它明確選擇退出。
 
 ### 閉包
 
@@ -492,7 +492,7 @@ Swift 團隊建議 [Task.detached 作為最後手段](https://forums.swift.org/t
 
 Swift 並發可能感覺像很多概念：`async/await`、`Task`、actors、`MainActor`、`Sendable`、隔離域。但其實只有一個核心想法：**隔離預設是繼承的**。
 
-有了[易於使用的並發](https://www.swift.org/documentation/articles/swift-6.2-release-notes.html)啟用，你的 app 從 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 開始。這是你的起點。從那裡：
+有了[易於使用的並發](https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency)啟用，你的 app 從 [`MainActor`](https://developer.apple.com/documentation/swift/mainactor) 開始。這是你的起點。從那裡：
 
 - 你呼叫的每個函式**繼承**那個隔離
 - 你建立的每個閉包**捕獲**那個隔離


### PR DESCRIPTION
Got a 404 for https://www.swift.org/documentation/articles/swift-6.2-release-notes.html
So updated it to: https://www.swift.org/blog/swift-6.2-released/#approachable-concurrency

Thank you, this is a great document!