### PR TITLE
feat: add AI agent skill for Swift Concurrency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,31 @@ The site is designed for deployment on:
 
 The `_redirects` file handles language-based routing using the Accept-Language header.
 
+## AI Agent Skill
+
+The project includes a **SKILL.md** file at `src/SKILL.md` that packages the Swift Concurrency knowledge for use with AI coding agents (Claude Code, Cursor, etc.).
+
+### Keeping SKILL.md in Sync
+
+When updating content in the language files (especially `src/en/index.md`), ensure that significant changes are reflected in `src/SKILL.md`:
+
+- New concepts or mental models
+- Updated best practices or recommendations
+- New common mistakes or pitfalls
+- Changes to the "Office Building" analogy
+- Updates related to new Swift versions (e.g., Swift 6.2 Approachable Concurrency)
+
+The skill file should remain a condensed, actionable reference. It does not need to mirror every detail, but should capture the essential guidance that helps developers write correct concurrent Swift code.
+
+### Skill Distribution
+
+The SKILL.md file is served as a static asset at `https://fuckingapproachableswiftconcurrency.com/SKILL.md`. Users can:
+
+1. Download it directly and place it in their agent's skills directory
+2. Reference it in their agent configuration
+3. Use it as a personal skill (`~/.claude/skills/swift-concurrency/SKILL.md`)
+4. Use it as a project skill (`.claude/skills/swift-concurrency/SKILL.md`)
+
 ## Credits
 
 - Original content and mental models inspired by [Matt Massicotte's blog](https://www.massicotte.org/)

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -6,6 +6,7 @@ export default function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/css");
   eleventyConfig.addPassthroughCopy("src/images");
   eleventyConfig.addPassthroughCopy("src/_redirects");
+  eleventyConfig.addPassthroughCopy("src/SKILL.md");
 
   // Add language data globally
   eleventyConfig.addGlobalData("languages", {

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: swift-concurrency
+description: Expert guidance on Swift Concurrency concepts. Use when working with async/await, Tasks, actors, MainActor, Sendable, isolation domains, or debugging concurrency compiler errors. Helps write safe concurrent Swift code.
+---
+
+# Swift Concurrency Skill
+
+This skill provides expert guidance on Swift's concurrency system based on the mental models from [Fucking Approachable Swift Concurrency](https://fuckingapproachableswiftconcurrency.com).
+
+## Core Mental Model: The Office Building
+
+Think of your app as an office building where **isolation domains** are private offices with locks:
+
+- **MainActor** = Front desk (handles all UI interactions, only one exists)
+- **actor** types = Department offices (Accounting, Legal, HR - each protects its own data)
+- **nonisolated** code = Hallways (shared space, no private documents)
+- **Sendable** types = Photocopies (safe to share between offices)
+- **Non-Sendable** types = Original documents (must stay in one office)
+
+You can't barge into someone's office. You knock (`await`) and wait.
+
+## Async/Await
+
+An `async` function can pause. Use `await` to suspend until work finishes:
+
+```swift
+func fetchUser(id: Int) async throws -> User {
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return try JSONDecoder().decode(User.self, from: data)
+}
+```
+
+For parallel work, use `async let`:
+
+```swift
+async let avatar = fetchImage("avatar.jpg")
+async let banner = fetchImage("banner.jpg")
+return Profile(avatar: try await avatar, banner: try await banner)
+```
+
+## Tasks
+
+A `Task` is a unit of async work you can manage:
+
+```swift
+// SwiftUI - cancels when view disappears
+.task { avatar = await downloadAvatar() }
+
+// Manual task creation
+Task { await saveProfile() }
+
+// Parallel work with TaskGroup
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { avatar = try await downloadAvatar() }
+    group.addTask { bio = try await fetchBio() }
+    try await group.waitForAll()
+}
+```
+
+Child tasks in a group: cancellation propagates, errors cancel siblings, waits for all to complete.
+
+## Isolation Domains
+
+Swift asks "who can access this data?" not "which thread?". Three isolation domains:
+
+### 1. MainActor
+
+For UI. Everything UI-related should be here:
+
+```swift
+@MainActor
+class ViewModel {
+    var items: [Item] = []  // Protected by MainActor
+}
+```
+
+### 2. Actors
+
+Protect their own mutable state with exclusive access:
+
+```swift
+actor BankAccount {
+    var balance: Double = 0
+    func deposit(_ amount: Double) { balance += amount }
+}
+
+await account.deposit(100)  // Must await from outside
+```
+
+### 3. Nonisolated
+
+Opts out of actor isolation. Cannot access actor's protected state:
+
+```swift
+actor BankAccount {
+    nonisolated func bankName() -> String { "Acme Bank" }
+}
+let name = account.bankName()  // No await needed
+```
+
+## Approachable Concurrency (Swift 6.2+)
+
+Two build settings that simplify the mental model:
+
+- **SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor**: Everything runs on MainActor unless you say otherwise
+- **SWIFT_APPROACHABLE_CONCURRENCY = YES**: nonisolated async functions stay on caller's actor
+
+```swift
+// Runs on MainActor (default)
+func updateUI() async { }
+
+// Runs on background (opt-in)
+@concurrent func processLargeFile() async { }
+```
+
+## Sendable
+
+Marks types safe to pass across isolation boundaries:
+
+```swift
+// Sendable - value type, each gets a copy
+struct User: Sendable {
+    let id: Int
+    let name: String
+}
+
+// Non-Sendable - mutable class state
+class Counter {
+    var count = 0
+}
+```
+
+Automatically Sendable:
+- Structs/enums with only Sendable properties
+- Actors (protect their own state)
+- @MainActor types (MainActor serializes access)
+
+For thread-safe classes with internal synchronization:
+
+```swift
+final class ThreadSafeCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: Data] = [:]
+}
+```
+
+## Isolation Inheritance
+
+With Approachable Concurrency, isolation flows from MainActor through your code:
+
+- **Functions**: Inherit caller's isolation unless explicitly marked
+- **Closures**: Inherit from context where defined
+- **Task { }**: Inherits actor isolation from creation site
+- **Task.detached { }**: No inheritance (rarely needed)
+
+## Common Mistakes to Avoid
+
+### 1. Thinking async = background
+
+```swift
+// Still blocks main thread!
+@MainActor func slowFunction() async {
+    let result = expensiveCalculation()  // Synchronous = blocking
+}
+// Fix: Use @concurrent for CPU-heavy work
+```
+
+### 2. Creating too many actors
+
+Most things can live on MainActor. Only create actors when you have shared mutable state that can't be on MainActor.
+
+### 3. Making everything Sendable
+
+Not everything needs to cross boundaries. Step back and ask if data actually moves between isolation domains.
+
+### 4. Using MainActor.run unnecessarily
+
+```swift
+// Unnecessary
+await MainActor.run { self.data = data }
+
+// Better - annotate the function
+@MainActor func loadData() async { self.data = await fetchData() }
+```
+
+### 5. Blocking the cooperative thread pool
+
+Never use DispatchSemaphore, DispatchGroup.wait() in async code. Risks deadlock.
+
+### 6. Creating unnecessary Tasks
+
+```swift
+// Bad - unstructured
+Task { await fetchUsers() }
+Task { await fetchPosts() }
+
+// Good - structured concurrency
+async let users = fetchUsers()
+async let posts = fetchPosts()
+await (users, posts)
+```
+
+## Quick Reference
+
+| Keyword | Purpose |
+|---------|---------|
+| `async` | Function can pause |
+| `await` | Pause here until done |
+| `Task { }` | Start async work, inherits context |
+| `Task.detached { }` | Start async work, no context |
+| `@MainActor` | Runs on main thread |
+| `actor` | Type with isolated mutable state |
+| `nonisolated` | Opts out of actor isolation |
+| `Sendable` | Safe to pass between isolation domains |
+| `@concurrent` | Always run on background (Swift 6.2+) |
+| `async let` | Start parallel work |
+| `TaskGroup` | Dynamic parallel work |
+
+## When the Compiler Complains
+
+Trace the isolation: Where did it come from? Where is code trying to run? What data crosses a boundary?
+
+The answer is usually obvious once you ask the right question.
+
+## Further Reading
+
+- [Matt Massicotte's Blog](https://www.massicotte.org/) - The source of these mental models
+- [Swift Concurrency Documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)
+- [WWDC21: Meet async/await](https://developer.apple.com/videos/play/wwdc2021/10132/)
+- [WWDC21: Protect mutable state with actors](https://developer.apple.com/videos/play/wwdc2021/10133/)

--- a/src/ar/index.md
+++ b/src/ar/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | ابدأ عملاً متوازياً |
 | `TaskGroup` | عمل متوازي ديناميكي |
 
-## قراءة إضافية
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [قراءة إضافية](#further-reading)
 
 <div class="resources">
 <h4>مدونة Matt Massicotte (موصى به بشدة)</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - طوّر أسرع مع فرق ومشاريع أكبر
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [مهارة وكيل الذكاء الاصطناعي](#ai-skill)
+
+هل تريد أن يفهم مساعد البرمجة بالذكاء الاصطناعي Swift Concurrency؟ نقدم ملف **[SKILL.md](/SKILL.md)** الذي يحزم هذه النماذج الذهنية لوكلاء الذكاء الاصطناعي مثل Claude Code و Codex و Amp و OpenCode وغيرها.
+
+<div class="tip">
+<h4>ما هي المهارة؟</h4>
+
+المهارة هي ملف markdown يعلّم وكلاء البرمجة بالذكاء الاصطناعي معرفة متخصصة. عندما تضيف مهارة Swift Concurrency إلى وكيلك، فإنه يطبق هذه المفاهيم تلقائياً عند مساعدتك في كتابة كود Swift غير متزامن.
+</div>
+
+### كيفية الاستخدام
+
+اختر وكيلك ونفّذ الأوامر:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# مهارة شخصية (جميع مشاريعك)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# مهارة المشروع (هذا المشروع فقط)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# تعليمات عامة (جميع مشاريعك)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# تعليمات المشروع (هذا المشروع فقط)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# تعليمات المشروع (موصى به)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# قواعد عامة (جميع مشاريعك)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# قواعد المشروع (هذا المشروع فقط)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+تتضمن المهارة تشبيه مبنى المكاتب، وأنماط العزل، ودليل Sendable، والأخطاء الشائعة، وجداول المرجع السريع. سيستخدم وكيلك هذه المعرفة تلقائياً عند العمل مع كود Swift Concurrency.
 
   </div>
 </section>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -400,6 +400,15 @@ p {
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
   transition: color 0.15s, border-color 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.code-tabs-nav button svg {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
 }
 
 .code-tabs-nav button:hover {

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -648,7 +648,13 @@ If you're already in an async context, prefer structured concurrency (`async let
 | `async let` | Start parallel work |
 | `TaskGroup` | Dynamic parallel work |
 
-## Further Reading
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [Further Reading](#further-reading)
 
 <div class="resources">
 <h4>Matt Massicotte's Blog (Highly Recommended)</h4>
@@ -672,6 +678,78 @@ If you're already in an async context, prefer structured concurrency (`async let
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - Ship faster with larger teams and codebases
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [AI Agent Skill](#ai-skill)
+
+Want your AI coding assistant to understand Swift Concurrency? We provide a **[SKILL.md](/SKILL.md)** file that packages these mental models for AI agents like Claude Code, Codex, Amp, OpenCode, and others.
+
+<div class="tip">
+<h4>What is a Skill?</h4>
+
+A skill is a markdown file that teaches AI coding agents specialized knowledge. When you add the Swift Concurrency skill to your agent, it automatically applies these concepts when helping you write async Swift code.
+</div>
+
+### How to Use
+
+Choose your agent and run the commands below:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# Personal skill (all your projects)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Project skill (just this project)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Global instructions (all your projects)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Project instructions (just this project)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Project instructions (recommended)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Global rules (all your projects)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Project rules (just this project)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+The skill includes the Office Building analogy, isolation patterns, Sendable guidance, common mistakes, and quick reference tables. Your agent will use this knowledge automatically when you work with Swift Concurrency code.
 
   </div>
 </section>

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -650,7 +650,13 @@ Si ya estás en un contexto async, prefiere la concurrencia estructurada (`async
 | `async let` | Inicia trabajo paralelo |
 | `TaskGroup` | Trabajo paralelo dinámico |
 
-## Lectura Adicional
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [Lectura Adicional](#further-reading)
 
 <div class="resources">
 <h4>Blog de Matt Massicotte (Muy Recomendado)</h4>
@@ -674,6 +680,78 @@ Si ya estás en un contexto async, prefiere la concurrencia estructurada (`async
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - Desarrolla más rápido con equipos y proyectos grandes
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [Skill para Agentes IA](#ai-skill)
+
+¿Quieres que tu asistente de código IA entienda Swift Concurrency? Proporcionamos un archivo **[SKILL.md](/SKILL.md)** que empaqueta estos modelos mentales para agentes IA como Claude Code, Codex, Amp, OpenCode y otros.
+
+<div class="tip">
+<h4>¿Qué es un Skill?</h4>
+
+Un skill es un archivo markdown que enseña conocimientos especializados a los agentes de código IA. Cuando añades el skill de Swift Concurrency a tu agente, automáticamente aplica estos conceptos cuando te ayuda a escribir código Swift asíncrono.
+</div>
+
+### Cómo Usar
+
+Elige tu agente y ejecuta los comandos:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# Skill personal (todos tus proyectos)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Skill de proyecto (solo este proyecto)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instrucciones globales (todos tus proyectos)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Instrucciones de proyecto (solo este proyecto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instrucciones de proyecto (recomendado)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Reglas globales (todos tus proyectos)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Reglas de proyecto (solo este proyecto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+El skill incluye la analogía del Edificio de Oficinas, patrones de aislamiento, guía de Sendable, errores comunes y tablas de referencia rápida. Tu agente usará este conocimiento automáticamente cuando trabajes con código Swift Concurrency.
 
   </div>
 </section>

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | 並列作業を開始 |
 | `TaskGroup` | 動的な並列作業 |
 
-## 参考資料
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [参考資料](#further-reading)
 
 <div class="resources">
 <h4>Matt Massicotte のブログ（強く推奨）</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - 大規模なチームとコードベースでより速く開発
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [AI エージェントスキル](#ai-skill)
+
+AI コーディングアシスタントに Swift Concurrency を理解させたいですか？Claude Code、Codex、Amp、OpenCode などの AI エージェント向けに、これらのメンタルモデルをパッケージ化した **[SKILL.md](/SKILL.md)** ファイルを提供しています。
+
+<div class="tip">
+<h4>スキルとは？</h4>
+
+スキルは AI コーディングエージェントに専門知識を教える markdown ファイルです。Swift Concurrency スキルをエージェントに追加すると、非同期 Swift コードの作成を支援する際にこれらの概念を自動的に適用します。
+</div>
+
+### 使い方
+
+エージェントを選択してコマンドを実行してください：
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# 個人スキル（すべてのプロジェクト）
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# プロジェクトスキル（このプロジェクトのみ）
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# グローバル指示（すべてのプロジェクト）
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# プロジェクト指示（このプロジェクトのみ）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# プロジェクト指示（推奨）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# グローバルルール（すべてのプロジェクト）
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# プロジェクトルール（このプロジェクトのみ）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+このスキルには、オフィスビルの比喩、隔離パターン、Sendable ガイド、よくある間違い、クイックリファレンス表が含まれています。Swift Concurrency コードを扱う際に、エージェントがこの知識を自動的に活用します。
 
   </div>
 </section>

--- a/src/ko/index.md
+++ b/src/ko/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | 병렬 작업 시작 |
 | `TaskGroup` | 동적 병렬 작업 |
 
-## 더 읽을 거리
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [더 읽을 거리](#further-reading)
 
 <div class="resources">
 <h4>Matt Massicotte의 블로그 (강력 추천)</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - 더 큰 팀과 코드베이스로 더 빠르게 개발하세요
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [AI 에이전트 스킬](#ai-skill)
+
+AI 코딩 어시스턴트가 Swift Concurrency를 이해하길 원하시나요? Claude Code, Codex, Amp, OpenCode 등의 AI 에이전트를 위해 이러한 멘탈 모델을 패키징한 **[SKILL.md](/SKILL.md)** 파일을 제공합니다.
+
+<div class="tip">
+<h4>스킬이란?</h4>
+
+스킬은 AI 코딩 에이전트에게 전문 지식을 가르치는 마크다운 파일입니다. Swift Concurrency 스킬을 에이전트에 추가하면, 비동기 Swift 코드 작성을 도와줄 때 이러한 개념들을 자동으로 적용합니다.
+</div>
+
+### 사용 방법
+
+에이전트를 선택하고 명령어를 실행하세요:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# 개인 스킬 (모든 프로젝트)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 프로젝트 스킬 (이 프로젝트만)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 글로벌 지침 (모든 프로젝트)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 프로젝트 지침 (이 프로젝트만)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 프로젝트 지침 (권장)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 글로벌 규칙 (모든 프로젝트)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 프로젝트 규칙 (이 프로젝트만)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+이 스킬에는 오피스 빌딩 비유, 격리 패턴, Sendable 가이드, 흔한 실수, 빠른 참조 표가 포함되어 있습니다. 에이전트가 Swift Concurrency 코드 작업 시 이 지식을 자동으로 활용합니다.
 
   </div>
 </section>

--- a/src/pt-BR/index.md
+++ b/src/pt-BR/index.md
@@ -650,7 +650,13 @@ Se você já está em um contexto async, prefira concorrência estruturada (`asy
 | `async let` | Inicia trabalho paralelo |
 | `TaskGroup` | Trabalho paralelo dinâmico |
 
-## Leitura Adicional
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [Leitura Adicional](#further-reading)
 
 <div class="resources">
 <h4>Blog do Matt Massicotte (Altamente Recomendado)</h4>
@@ -674,6 +680,78 @@ Se você já está em um contexto async, prefira concorrência estruturada (`asy
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - Desenvolva mais rápido com equipes e projetos maiores
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [Skill para Agentes IA](#ai-skill)
+
+Quer que seu assistente de código IA entenda Swift Concurrency? Fornecemos um arquivo **[SKILL.md](/SKILL.md)** que empacota esses modelos mentais para agentes IA como Claude Code, Codex, Amp, OpenCode e outros.
+
+<div class="tip">
+<h4>O que é um Skill?</h4>
+
+Um skill é um arquivo markdown que ensina conhecimentos especializados para agentes de código IA. Quando você adiciona o skill de Swift Concurrency ao seu agente, ele automaticamente aplica esses conceitos quando te ajuda a escrever código Swift assíncrono.
+</div>
+
+### Como Usar
+
+Escolha seu agente e execute os comandos:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# Skill pessoal (todos os seus projetos)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Skill de projeto (apenas este projeto)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instruções globais (todos os seus projetos)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Instruções de projeto (apenas este projeto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instruções de projeto (recomendado)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Regras globais (todos os seus projetos)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Regras de projeto (apenas este projeto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+O skill inclui a analogia do Edifício de Escritórios, padrões de isolamento, guia de Sendable, erros comuns e tabelas de referência rápida. Seu agente usará esse conhecimento automaticamente quando você trabalhar com código Swift Concurrency.
 
   </div>
 </section>

--- a/src/pt-PT/index.md
+++ b/src/pt-PT/index.md
@@ -650,7 +650,13 @@ Se já estás num contexto async, prefere concorrência estruturada (`async let`
 | `async let` | Inicia trabalho paralelo |
 | `TaskGroup` | Trabalho paralelo dinâmico |
 
-## Leitura Adicional
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [Leitura Adicional](#further-reading)
 
 <div class="resources">
 <h4>Blog do Matt Massicotte (Altamente Recomendado)</h4>
@@ -674,6 +680,78 @@ Se já estás num contexto async, prefere concorrência estruturada (`async let`
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - Desenvolve mais rápido com equipas e projetos maiores
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [Skill para Agentes IA](#ai-skill)
+
+Queres que o teu assistente de código IA compreenda Swift Concurrency? Fornecemos um ficheiro **[SKILL.md](/SKILL.md)** que empacota estes modelos mentais para agentes IA como Claude Code, Codex, Amp, OpenCode e outros.
+
+<div class="tip">
+<h4>O que é um Skill?</h4>
+
+Um skill é um ficheiro markdown que ensina conhecimentos especializados a agentes de código IA. Quando adicionas o skill de Swift Concurrency ao teu agente, ele aplica automaticamente estes conceitos quando te ajuda a escrever código Swift assíncrono.
+</div>
+
+### Como Usar
+
+Escolhe o teu agente e executa os comandos:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# Skill pessoal (todos os teus projetos)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Skill de projeto (apenas este projeto)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instruções globais (todos os teus projetos)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Instruções de projeto (apenas este projeto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Instruções de projeto (recomendado)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Regras globais (todos os teus projetos)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Regras de projeto (apenas este projeto)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+O skill inclui a analogia do Edifício de Escritórios, padrões de isolamento, guia de Sendable, erros comuns e tabelas de referência rápida. O teu agente usará este conhecimento automaticamente quando trabalhares com código Swift Concurrency.
 
   </div>
 </section>

--- a/src/ru/index.md
+++ b/src/ru/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | Запустить параллельную работу |
 | `TaskGroup` | Динамическая параллельная работа |
 
-## Дополнительное чтение
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [Дополнительное чтение](#further-reading)
 
 <div class="resources">
 <h4>Блог Matt Massicotte (очень рекомендуется)</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - Разрабатывайте быстрее с большими командами и кодовыми базами
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [Навык для ИИ-агентов](#ai-skill)
+
+Хотите, чтобы ваш ИИ-помощник по коду понимал Swift Concurrency? Мы предоставляем файл **[SKILL.md](/SKILL.md)**, который упаковывает эти ментальные модели для ИИ-агентов, таких как Claude Code, Codex, Amp, OpenCode и других.
+
+<div class="tip">
+<h4>Что такое навык?</h4>
+
+Навык - это markdown-файл, который обучает ИИ-агентов специализированным знаниям. Когда вы добавляете навык Swift Concurrency к вашему агенту, он автоматически применяет эти концепции при помощи в написании асинхронного Swift-кода.
+</div>
+
+### Как использовать
+
+Выберите вашего агента и выполните команды:
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# Личный навык (все ваши проекты)
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Навык проекта (только этот проект)
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Глобальные инструкции (все ваши проекты)
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Инструкции проекта (только этот проект)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Инструкции проекта (рекомендуется)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# Глобальные правила (все ваши проекты)
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# Правила проекта (только этот проект)
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+Навык включает аналогию офисного здания, паттерны изоляции, руководство по Sendable, распространённые ошибки и таблицы быстрого справочника. Ваш агент автоматически использует эти знания при работе с кодом Swift Concurrency.
 
   </div>
 </section>

--- a/src/zh-CN/index.md
+++ b/src/zh-CN/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | 开始并行工作 |
 | `TaskGroup` | 动态并行工作 |
 
-## 延伸阅读
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [延伸阅读](#further-reading)
 
 <div class="resources">
 <h4>Matt Massicotte 的博客(强烈推荐)</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - 让大型团队和代码库开发更快
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [AI 代理技能](#ai-skill)
+
+想让你的 AI 编程助手理解 Swift Concurrency？我们提供一个 **[SKILL.md](/SKILL.md)** 文件，为 Claude Code、Codex、Amp、OpenCode 等 AI 代理打包了这些心智模型。
+
+<div class="tip">
+<h4>什么是技能？</h4>
+
+技能是一个 markdown 文件，用于向 AI 编程代理教授专业知识。当你将 Swift Concurrency 技能添加到代理时，它会在帮助你编写异步 Swift 代码时自动应用这些概念。
+</div>
+
+### 如何使用
+
+选择你的代理并运行命令：
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# 个人技能（所有项目）
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 项目技能（仅此项目）
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 全局指令（所有项目）
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 项目指令（仅此项目）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 项目指令（推荐）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 全局规则（所有项目）
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 项目规则（仅此项目）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+该技能包含办公大楼比喻、隔离模式、Sendable 指南、常见错误和快速参考表。当你处理 Swift Concurrency 代码时，代理会自动使用这些知识。
 
   </div>
 </section>

--- a/src/zh-TW/index.md
+++ b/src/zh-TW/index.md
@@ -650,7 +650,13 @@ func fetchAll() async {
 | `async let` | 開始並行工作 |
 | `TaskGroup` | 動態並行工作 |
 
-## 延伸閱讀
+  </div>
+</section>
+
+<section id="further-reading">
+  <div class="container">
+
+## [延伸閱讀](#further-reading)
 
 <div class="resources">
 <h4>Matt Massicotte 的部落格（強烈推薦）</h4>
@@ -674,6 +680,78 @@ func fetchAll() async {
 
 - [Tuist](https://tuist.dev?utm_source=fuckingapproachableswiftconcurrency&utm_medium=website&utm_campaign=tools) - 讓大型團隊和程式碼庫開發更快
 </div>
+
+  </div>
+</section>
+
+<section id="ai-skill">
+  <div class="container">
+
+## [AI 代理技能](#ai-skill)
+
+想讓你的 AI 程式碼助手理解 Swift Concurrency？我們提供一個 **[SKILL.md](/SKILL.md)** 檔案，為 Claude Code、Codex、Amp、OpenCode 等 AI 代理打包了這些心智模型。
+
+<div class="tip">
+<h4>什麼是技能？</h4>
+
+技能是一個 markdown 檔案，用於向 AI 程式碼代理教授專業知識。當你將 Swift Concurrency 技能加入代理時，它會在協助你撰寫非同步 Swift 程式碼時自動套用這些概念。
+</div>
+
+### 如何使用
+
+選擇你的代理並執行命令：
+
+<div class="code-tabs">
+  <div class="code-tabs-nav">
+    <button class="active">Claude Code</button>
+    <button>Codex</button>
+    <button>Amp</button>
+    <button>OpenCode</button>
+  </div>
+  <div class="code-tab-content active">
+
+```bash
+# 個人技能（所有專案）
+mkdir -p ~/.claude/skills/swift-concurrency
+curl -o ~/.claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 專案技能（僅此專案）
+mkdir -p .claude/skills/swift-concurrency
+curl -o .claude/skills/swift-concurrency/SKILL.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 全域指令（所有專案）
+curl -o ~/.codex/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 專案指令（僅此專案）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 專案指令（推薦）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+  <div class="code-tab-content">
+
+```bash
+# 全域規則（所有專案）
+mkdir -p ~/.config/opencode
+curl -o ~/.config/opencode/AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+# 專案規則（僅此專案）
+curl -o AGENTS.md https://fuckingapproachableswiftconcurrency.com/SKILL.md
+```
+
+  </div>
+</div>
+
+該技能包含辦公大樓比喻、隔離模式、Sendable 指南、常見錯誤和快速參考表。當你處理 Swift Concurrency 程式碼時，代理會自動使用這些知識。
 
   </div>
 </section>


### PR DESCRIPTION
## Summary

This adds the ability for AI coding agents to learn Swift Concurrency concepts from the site. The knowledge is packaged as a SKILL.md file that agents can download and reference.

The website now includes a new "AI Agent Skill" section (in all 10 languages) that explains what the skill is and provides installation instructions for different AI coding assistants: Claude Code, Codex, Amp, and OpenCode.

## Changes

- Created `src/SKILL.md` with Swift Concurrency knowledge for AI agents
- Added passthrough copy in Eleventy config so SKILL.md is served as a static asset
- Added AI Agent Skill section to all language versions with code tabs showing installation commands
- Updated AGENTS.md with instructions to keep SKILL.md in sync when content changes