### PR TITLE
Enhance README with local development instructions for language routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,7 @@ pnpm install
 pnpm dev
 ```
 
-Then open **http://localhost:8080/en/** in your browser. 
-> You can switch to other languages using the language selector at the top of the page.
-
-<details><summary>Explanation</summary>
-
-In local development, you must access a specific language path (e.g., `/en/`, `/es/`, `/ko/`) directly. The root URL (`http://localhost:8080/`) will return a 404 because Eleventy's dev server doesn't process the `_redirects` file. Language-based routing only works in production when deployed to Netlify or Cloudflare Pages, which read the `_redirects` file and use the `Accept-Language` header to automatically route users to their preferred language.
-</details>
+Then open **http://localhost:8080/** in your browser.
 
 ### Build
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -22,6 +22,16 @@ export default function(eleventyConfig) {
     ru: { name: "Russian", dir: "ltr", native: "Русский" }
   });
 
+  // Dev server configuration: redirect root to /en/
+  eleventyConfig.setServerOptions({
+    onRequest: {
+      "/": function({ url }) {
+        const redirectUrl = new URL("/en/", url);
+        return Response.redirect(redirectUrl, 302);
+      }
+    }
+  });
+
   return {
     dir: {
       input: "src",


### PR DESCRIPTION
I tried running the project locally as instructed in the terminal, but encountered a 404 error:

```shell
[11ty] Copied 9 Wrote 11 files in 0.34 seconds (v3.1.2)
[11ty] Watching…
[11ty] Server at http://localhost:8080/
```` 

After investigating, I found that the project relies on **Netlify** `_redirects`, which do not work in the local environment.
To address this, I’ve decided to explicitly add this information to the `README.md`.