### PR TITLE
Add Agent Skill section for Swift Concurrency in multiple languages

### DIFF
--- a/src/ar/index.md
+++ b/src/ar/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 هل تريد أن يفهم مساعد البرمجة بالذكاء الاصطناعي Swift Concurrency؟ نقدم ملف **[SKILL.md](/SKILL.md)** الذي يحزم هذه النماذج الذهنية لوكلاء الذكاء الاصطناعي مثل Claude Code و Codex و Amp و OpenCode وغيرها.
 
-يمكنك أيضاً الاطلاع على مهارة Swift Concurrency Agent مفتوحة المصدر من Antoine على <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### مهارات أخرى
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">مهارة Swift Concurrency Agent مفتوحة المصدر من Antoine</a>
 
 <div class="tip">
 <h4>ما هي المهارة؟</h4>

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -841,7 +841,9 @@ struct ContentView: View {
 
 Want your AI coding assistant to understand Swift Concurrency? We provide a **[SKILL.md](/SKILL.md)** file that packages these mental models for AI agents like Claude Code, Codex, Amp, OpenCode, and others.
 
-Additionally, you can check out Antoine's open-sourced Swift Concurrency Agent Skill at <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### Other skills
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine's open-sourced Swift Concurrency Agent Skill</a>
 
 <div class="tip">
 <h4>What is a Skill?</h4>

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 ¿Quieres que tu asistente de código IA entienda Swift Concurrency? Proporcionamos un archivo **[SKILL.md](/SKILL.md)** que empaqueta estos modelos mentales para agentes IA como Claude Code, Codex, Amp, OpenCode y otros.
 
-Además, puedes consultar el Swift Concurrency Agent Skill de código abierto de Antoine en <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### Otras skills
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Swift Concurrency Agent Skill de código abierto de Antoine</a>
 
 <div class="tip">
 <h4>¿Qué es un Skill?</h4>

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 AI コーディングアシスタントに Swift Concurrency を理解させたいですか？Claude Code、Codex、Amp、OpenCode などの AI エージェント向けに、これらのメンタルモデルをパッケージ化した **[SKILL.md](/SKILL.md)** ファイルを提供しています。
 
-また、Antoine がオープンソースで公開している Swift Concurrency Agent Skill を <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a> で確認できます。
+### その他のスキル
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine がオープンソースで公開している Swift Concurrency Agent Skill</a>
 
 <div class="tip">
 <h4>スキルとは？</h4>

--- a/src/ko/index.md
+++ b/src/ko/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 AI 코딩 어시스턴트가 Swift Concurrency를 이해하길 원하시나요? Claude Code, Codex, Amp, OpenCode 등의 AI 에이전트를 위해 이러한 멘탈 모델을 패키징한 **[SKILL.md](/SKILL.md)** 파일을 제공합니다.
 
-추가로 Antoine이 오픈 소스로 공개한 Swift Concurrency Agent Skill을 <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>에서 확인할 수 있습니다.
+### 다른 스킬
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine이 오픈 소스로 공개한 Swift Concurrency Agent Skill</a>
 
 <div class="tip">
 <h4>스킬이란?</h4>

--- a/src/pt-BR/index.md
+++ b/src/pt-BR/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 Quer que seu assistente de código IA entenda Swift Concurrency? Fornecemos um arquivo **[SKILL.md](/SKILL.md)** que empacota esses modelos mentais para agentes IA como Claude Code, Codex, Amp, OpenCode e outros.
 
-Além disso, você pode conferir o Swift Concurrency Agent Skill de código aberto do Antoine em <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### Outras skills
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Swift Concurrency Agent Skill de código aberto do Antoine</a>
 
 <div class="tip">
 <h4>O que é um Skill?</h4>

--- a/src/pt-PT/index.md
+++ b/src/pt-PT/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 Queres que o teu assistente de código IA compreenda Swift Concurrency? Fornecemos um ficheiro **[SKILL.md](/SKILL.md)** que empacota estes modelos mentais para agentes IA como Claude Code, Codex, Amp, OpenCode e outros.
 
-Além disso, podes consultar o Swift Concurrency Agent Skill open source do Antoine em <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### Outras skills
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Swift Concurrency Agent Skill open source do Antoine</a>
 
 <div class="tip">
 <h4>O que é um Skill?</h4>

--- a/src/ru/index.md
+++ b/src/ru/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 Хотите, чтобы ваш ИИ-помощник по коду понимал Swift Concurrency? Мы предоставляем файл **[SKILL.md](/SKILL.md)**, который упаковывает эти ментальные модели для ИИ-агентов, таких как Claude Code, Codex, Amp, OpenCode и других.
 
-Кроме того, можно посмотреть открытый Swift Concurrency Agent Skill Антуана на <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>.
+### Другие навыки
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Swift Concurrency Agent Skill с открытым исходным кодом от Антуана</a>
 
 <div class="tip">
 <h4>Что такое навык?</h4>

--- a/src/tr/index.md
+++ b/src/tr/index.md
@@ -778,7 +778,9 @@ Eğer zaten asenkron bir bağlamdaysanız, yeni unstructured `Task`'lar oluştur
 
 Yapay zeka kodlama asistanınızın Swift Concurrency mantığını kavramasını mı istiyorsunuz? Bu mental modelleri; Claude Code, Codex, Amp, OpenCode ve diğer AI ajanları için paketlenmiş bir **[SKILL.md](/SKILL.md)** dosyası olarak sunuyoruz.
 
-Ayrıca Antoine'ın açık kaynak Swift Concurrency Agent Skill'ine <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a> adresinden göz atabilirsiniz.
+### Diğer yetenekler
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine'ın açık kaynak Swift Concurrency Agent Skill'i</a>
 
 <div class="tip">
 <h4>Yetenek nedir?</h4>

--- a/src/zh-CN/index.md
+++ b/src/zh-CN/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 想让你的 AI 编程助手理解 Swift Concurrency？我们提供一个 **[SKILL.md](/SKILL.md)** 文件，为 Claude Code、Codex、Amp、OpenCode 等 AI 代理打包了这些心智模型。
 
-另外，可以查看 Antoine 开源的 Swift Concurrency Agent Skill：<a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a>。
+### 其他技能
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine 开源的 Swift Concurrency Agent Skill</a>
 
 <div class="tip">
 <h4>什么是技能？</h4>

--- a/src/zh-TW/index.md
+++ b/src/zh-TW/index.md
@@ -843,7 +843,9 @@ struct ContentView: View {
 
 想讓你的 AI 程式碼助手理解 Swift Concurrency？我們提供一個 **[SKILL.md](/SKILL.md)** 檔案，為 Claude Code、Codex、Amp、OpenCode 等 AI 代理打包了這些心智模型。
 
-另外，你可以在 <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">github.com/avdlee/swift-concurrency-agent-skill</a> 查看 Antoine 開源的 Swift Concurrency Agent Skill。
+### 其他技能
+
+- <a href="https://github.com/AvdLee/Swift-Concurrency-Agent-Skill" target="_blank" rel="noreferrer noopener">Antoine 開源的 Swift Concurrency Agent Skill</a>
 
 <div class="tip">
 <h4>什麼是技能？</h4>


### PR DESCRIPTION
Introduced a new section detailing the Agent Skill for Swift Concurrency, created by Antoine van der Lee. This addition includes links to the in-depth course and the open-source GitHub repository. Updates made to localization files for Arabic, Chinese (Simplified and Traditional), English, Spanish, Japanese, Korean, Portuguese (Brazil and Portugal), Russian, and Turkish.

<img width="2202" height="2394" alt="CleanShot 2026-01-12 at 13 53 44@2x" src="https://github.com/user-attachments/assets/3d71a810-cc67-44a7-9727-b0315f0d1d06" />
