### PR TITLE
Fix Task.detached example: the "heavy work" actually ran on the main actor

### DIFF
--- a/src/ar/index.md
+++ b/src/ar/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // عمل مكثف للمعالج
+    }
 }
 ```
 

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -487,6 +487,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU-intensive work
+    }
 }
 ```
 

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // Trabajo intensivo de CPU
+    }
 }
 ```
 

--- a/src/fr/index.md
+++ b/src/fr/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // Travail intensif en CPU
+    }
 }
 ```
 

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU 負荷の高い処理
+    }
 }
 ```
 

--- a/src/ko/index.md
+++ b/src/ko/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU 집약적인 작업
+    }
 }
 ```
 

--- a/src/pl/index.md
+++ b/src/pl/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // Praca intensywnie obciążająca CPU
+    }
 }
 ```
 

--- a/src/pt-BR/index.md
+++ b/src/pt-BR/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // Trabalho intensivo de CPU
+    }
 }
 ```
 

--- a/src/pt-PT/index.md
+++ b/src/pt-PT/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // Trabalho intensivo de CPU
+    }
 }
 ```
 

--- a/src/ru/index.md
+++ b/src/ru/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU-интенсивная работа
+    }
 }
 ```
 

--- a/src/tr/index.md
+++ b/src/tr/index.md
@@ -491,6 +491,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU yoğun iş
+    }
 }
 ```
 

--- a/src/uk/index.md
+++ b/src/uk/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU-інтенсивна робота
+    }
 }
 ```
 

--- a/src/zh-CN/index.md
+++ b/src/zh-CN/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU 密集型工作
+    }
 }
 ```
 

--- a/src/zh-TW/index.md
+++ b/src/zh-TW/index.md
@@ -489,6 +489,10 @@ class ViewModel {
             }
         }
     }
+
+    nonisolated func expensiveCalculation() async -> Data {
+        // CPU 密集型工作
+    }
 }
 ```
 


### PR DESCRIPTION
While reading the guide I got confused by the example in the "Breaking Inheritance: Task.detached" section. The comment says the work "runs on cooperative pool", but `expensiveCalculation()` is a method of the `@MainActor` class, so it's main-actor-isolated:

```swift
@MainActor
class ViewModel {
    func doHeavyWork() {
        Task.detached {
            // No actor isolation, runs on cooperative pool
            let result = await self.expensiveCalculation()  // <-- hops back to the main actor
            await MainActor.run {
                self.data = result  // Explicitly hop back
            }
        }
    }
}
```

Awaiting it from the detached task hops right back to the main actor – the heavy work runs there, and the detached task achieves nothing. I verified this at runtime: the calculation executes on the main thread.

Nothing in the context suggests that `expensiveCalculation()` is a nonisolated func – as a member of a `@MainActor` class it's the opposite by default. For someone who is just getting into Swift Concurrency this is easy to misread, so the function should be explicitly declared as nonisolated async right in the example:

```swift
nonisolated func expensiveCalculation() async -> Data {
    // CPU-intensive work
}
```

This holds under both semantics the guide discusses. With Approachable Concurrency (the mental model of the "How Isolation Propagates" section this example lives in), a nonisolated async method runs in the caller's context – so `Task.detached` is now exactly the thing that breaks inheritance and puts the work on the cooperative pool, which is the point of the section. Without those settings, a nonisolated async function moves off-actor anyway, so the example stays correct there too.

I considered `@concurrent` (which the warning below the example recommends), but here it would undermine the example: `@concurrent` moves the work off the main actor by itself, regardless of who calls it, turning `Task.detached` into redundant decoration – a confusing way to illustrate a section about `Task.detached`. The warning still steers readers toward `@concurrent` for real code; the example and the warning now complement each other instead of clashing.

Applied to all locales, code identical everywhere per the contribution guidelines.
